### PR TITLE
updated dockerfile to use nodejs 16 per their installation instructions

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -10,10 +10,19 @@ COPY ./requirements.txt .
 
 RUN apt-get update -y && \
     apt-get install -y netcat && \
-    apt-get install -y nodejs && \
-    apt-get install -y npm && \
     pip install --upgrade pip && \
     pip install -r requirements.txt
+
+RUN apt-get update && \
+    apt-get install -y ca-certificates curl gnupg && \
+    mkdir -p /etc/apt/keyrings && \
+    curl -fsSL https://deb.nodesource.com/gpgkey/nodesource-repo.gpg.key | gpg --dearmor -o /etc/apt/keyrings/nodesource.gpg
+
+RUN NODE_MAJOR=16 && \
+    echo "deb [signed-by=/etc/apt/keyrings/nodesource.gpg] https://deb.nodesource.com/node_$NODE_MAJOR.x nodistro main" | tee /etc/apt/sources.list.d/nodesource.list
+
+RUN apt-get update && \
+    apt-get install nodejs -y
 
 COPY ./entrypoint.sh .
 RUN chmod +x /code/entrypoint.sh


### PR DESCRIPTION
since debian's repository hasn't updated nodejs in quite some time. tailwind would fail to install correctly because many dependencies require nodejs>=14. I've changed the dockerfile to reflect nodejs' installation instructions for debian bullseye